### PR TITLE
Add previous status to userInfo of NSNotification

### DIFF
--- a/FXReachability/FXReachability.h
+++ b/FXReachability/FXReachability.h
@@ -40,6 +40,7 @@
 
 extern NSString *const FXReachabilityStatusDidChangeNotification;
 extern NSString *const FXReachabilityNotificationStatusKey;
+extern NSString *const FXReachabilityNotificationPreviousStatusKey;
 
 
 typedef NS_ENUM(NSInteger, FXReachabilityStatus)

--- a/FXReachability/FXReachability.m
+++ b/FXReachability/FXReachability.m
@@ -39,6 +39,7 @@
 
 NSString *const FXReachabilityStatusDidChangeNotification = @"FXReachabilityStatusDidChangeNotification";
 NSString *const FXReachabilityNotificationStatusKey = @"status";
+NSString *const FXReachabilityNotificationPreviousStatusKey = @"previousStatus";
 
 
 @interface FXReachability ()
@@ -76,8 +77,11 @@ static void ONEReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
     
     if (status != [FXReachability sharedInstance].status)
     {
+        FXReachabilityStatus previousStatus = [FXReachability sharedInstance].status;
         [FXReachability sharedInstance].status = status;
-        [[NSNotificationCenter defaultCenter] postNotificationName:FXReachabilityStatusDidChangeNotification object:[FXReachability sharedInstance] userInfo:@{FXReachabilityNotificationStatusKey: @(status)}];
+
+        NSDictionary *userInfo = @{FXReachabilityNotificationStatusKey: @(status), FXReachabilityNotificationPreviousStatusKey: @(previousStatus)};
+        [[NSNotificationCenter defaultCenter] postNotificationName:FXReachabilityStatusDidChangeNotification object:[FXReachability sharedInstance] userInfo:userInfo];
     }
 }
 


### PR DESCRIPTION
Previous status is useful to notify user that network is disconnected. I know FXReachability is designed to be as simple as possible, but I think this usage is ordinary for many developers and this should be contained in the library.
