### PR TITLE
Remove load method.

### DIFF
--- a/FXReachability/FXReachability.m
+++ b/FXReachability/FXReachability.m
@@ -98,11 +98,6 @@ static void FXReachabilityCallback(__unused SCNetworkReachabilityRef target, SCN
     }
 }
 
-+ (void)load
-{
-    [self performSelectorOnMainThread:@selector(sharedInstance) withObject:nil waitUntilDone:NO];
-}
-
 + (instancetype)sharedInstance
 {
     static FXReachability *instance;


### PR DESCRIPTION
`load` is called when the class is added to Obj-C runtime. Calling `load` forces sharedInstance to track reachability on FXDefaultHost, which is not desired behavior if someone would like to use `initWithHost` method.